### PR TITLE
Fix: Render deployment TypeScript build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces",
     "typecheck": "npm run typecheck --workspaces",
-    "build:shared": "cd packages/shared && npm run build",
-    "build:server": "npm run build:shared && cd packages/server && npm run build",
-    "build:client": "npm run build:shared && cd packages/client && npm run build",
+    "install:all": "npm install && npm install --workspaces",
+    "build:shared": "cd packages/shared && npm install && npm run build",
+    "build:server": "npm run build:shared && cd packages/server && npm install && npm run build",
+    "build:client": "npm run build:shared && cd packages/client && npm install && npm run build",
     "start:server": "cd packages/server && npm start",
     "start": "npm run start:server"
   },


### PR DESCRIPTION
## Fix Render Deployment - TypeScript Build Issues

### Problem
The deployment was failing with the error:
```
error TS2688: Cannot find type definition file for 'node'.
```

This was happening because npm workspaces wasn't installing dependencies in the individual packages during the Render build process.

### Solution
Updated the build scripts in the root `package.json` to explicitly run `npm install` in each workspace before building:

- `build:shared`: Now runs `npm install` in the shared package before building
- `build:server`: Ensures shared package dependencies are installed before building server
- `build:client`: Ensures shared package dependencies are installed before building client

### Changes
- Modified `package.json` build scripts to include `npm install` for each workspace
- Added `install:all` script for local development

### Testing
The deployment should now:
1. Install dependencies at the root level
2. Install dependencies in each workspace as needed
3. Successfully compile TypeScript with the proper type definitions

This fix ensures that all workspace dependencies are properly installed during the Render build process.