### PR TITLE
Fix: Remove postinstall script causing infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces",
     "typecheck": "npm run typecheck --workspaces",
-    "install:all": "npm install && npm install --workspaces",
+    "install:all": "npm install --workspaces",
     "build:shared": "cd packages/shared && npm ci && npm run build",
     "build:server": "npm run build:shared && cd packages/server && npm ci && npm run build",
     "build:client": "npm run build:shared && cd packages/client && npm ci && npm run build",
     "start:server": "cd packages/server && npm start",
-    "start": "npm run start:server",
-    "postinstall": "npm install --workspaces --include-workspace-root --legacy-peer-deps"
+    "start": "npm run start:server"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Fix Postinstall Script Infinite Loop

### Problem
The postinstall script was causing an infinite loop during the Render build process, preventing the deployment from completing.

### Solution
Removed the problematic `postinstall` script that was calling itself recursively. The npm workspace dependencies will be handled by the explicit `npm ci` commands in the build scripts instead.

### Changes
- Removed `postinstall` script from package.json
- Kept the improved build scripts that use `npm ci` for each workspace

This should allow the deployment to complete successfully.