### PR TITLE
URGENT: Fix package.json encoding error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,1 +1,29 @@
-ewogICJuYW1lIjogImNhdGFwdWx0LWV2ZW50LW1hbmFnZXIiLAogICJ2ZXJzaW9uIjogIjEuMC4wIiwKICAicHJpdmF0ZSI6IHRydWUsCiAgIndvcmtzcGFjZXMiOiBbCiAgICAicGFja2FnZXMvKiIKICBdLAogICJzY3JpcHRzIjogewogICAgImRldiI6ICJucG0gcnVuIGRldiAtLXdvcmtzcGFjZXMiLAogICAgImJ1aWxkIjogIm5wbSBydW4gYnVpbGQgLS13b3Jrc3BhY2VzIiwKICAgICJ0ZXN0IjogIm5wbSBydW4gdGVzdCAtLXdvcmtzcGFjZXMiLAogICAgImxpbnQiOiAibnBtIHJ1biBsaW50IC0td29ya3NwYWNlcyIsCiAgICAidHlwZWNoZWNrIjogIm5wbSBydW4gdHlwZWNoZWNrIC0td29ya3NwYWNlcyIsCiAgICAiaW5zdGFsbDphbGwiOiAibnBtIGluc3RhbGwgLS13b3Jrc3BhY2VzIiwKICAgICJidWlsZDpzaGFyZWQiOiAibnBtIHJ1biBidWlsZCAtLXdvcmtzcGFjZT1AY2F0YXB1bHQtZXZlbnQtbWFuYWdlci9zaGFyZWQiLAogICAgImJ1aWxkOnNlcnZlciI6ICJucG0gcnVuIGJ1aWxkOnNoYXJlZCAmJiBucG0gcnVuIGJ1aWxkIC0td29ya3NwYWNlPUBjYXRhcHVsdC1ldmVudC1tYW5hZ2VyL3NlcnZlciIsCiAgICAiYnVpbGQ6Y2xpZW50IjogIm5wbSBydW4gYnVpbGQ6c2hhcmVkICYmIG5wbSBydW4gYnVpbGQgLS13b3Jrc3BhY2U9QGNhdGFwdWx0LWV2ZW50LW1hbmFnZXIvY2xpZW50IiwKICAgICJzdGFydDpzZXJ2ZXIiOiAiY2QgcGFja2FnZXMvc2VydmVyICYmIG5wbSBzdGFydCIsCiAgICAic3RhcnQiOiAibnBtIHJ1biBzdGFydDpzZXJ2ZXIiLAogICAgImluc3RhbGw6Y2kiOiAibnBtIGNpIC0td29ya3NwYWNlcyAtLWluY2x1ZGUtd29ya3NwYWNlLXJvb3QiCiAgfSwKICAia2V5d29yZHMiOiBbXSwKICAiYXV0aG9yIjogIiIsCiAgImxpY2Vuc2UiOiAiSVNDIiwKICAiZGVzY3JpcHRpb24iOiAiQ2F0YXB1bHQgRXZlbnQgTWFuYWdlciAtIE1vbm9yZXBvIiwKICAiZGV2RGVwZW5kZW5jaWVzIjogewogICAgInR5cGVzY3JpcHQiOiAiXjUuOC4zIgogIH0KfQo=
+{
+  "name": "catapult-event-manager",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "npm run dev --workspaces",
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces",
+    "lint": "npm run lint --workspaces",
+    "typecheck": "npm run typecheck --workspaces",
+    "install:all": "npm install --workspaces",
+    "build:shared": "npm run build --workspace=@catapult-event-manager/shared",
+    "build:server": "npm run build:shared && npm run build --workspace=@catapult-event-manager/server",
+    "build:client": "npm run build:shared && npm run build --workspace=@catapult-event-manager/client",
+    "start:server": "cd packages/server && npm start",
+    "start": "npm run start:server",
+    "install:ci": "npm ci --workspaces --include-workspace-root"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "Catapult Event Manager - Monorepo",
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}


### PR DESCRIPTION
## Critical Fix
The package.json file was accidentally saved with base64-encoded content instead of plain JSON, causing npm install to fail.

This PR corrects the file content to be proper JSON format.