### PR TITLE
Urgent Fix: Prevent map errors in CampaignsList component

### DIFF
--- a/packages/client/src/components/campaigns/CampaignsList.tsx
+++ b/packages/client/src/components/campaigns/CampaignsList.tsx
@@ -121,7 +121,7 @@ export function CampaignsList({ eventId }: CampaignsListProps) {
                   <div className="flex items-center text-muted-foreground">
                     <Users className="h-4 w-4 mr-2" />
                     <span>
-                      {campaign.campaignGroups.length} group{campaign.campaignGroups.length !== 1 ? 's' : ''}
+                      {(campaign.campaignGroups || []).length} group{(campaign.campaignGroups || []).length !== 1 ? 's' : ''}
                     </span>
                   </div>
                   <div className="flex items-center text-muted-foreground">
@@ -130,7 +130,7 @@ export function CampaignsList({ eventId }: CampaignsListProps) {
                       Created {new Date(campaign.createdAt).toLocaleDateString()}
                     </span>
                   </div>
-                  {campaign.variables.length > 0 && (
+                  {campaign.variables && campaign.variables.length > 0 && (
                     <div className="flex flex-wrap gap-1">
                       {campaign.variables.map((variable) => (
                         <span


### PR DESCRIPTION
Problem: Users getting map errors when navigating to Email Campaigns page

Root cause: campaign.variables and campaign.campaignGroups can be undefined

Solution: Added null checks before accessing these properties

This is a critical production fix